### PR TITLE
Fix broken image links on "Give award" screen

### DIFF
--- a/pyweek/challenge/templates/challenge/upload_award.html
+++ b/pyweek/challenge/templates/challenge/upload_award.html
@@ -66,7 +66,7 @@ of your award may have differing sensibilities to yourself.</p>
               <input type="radio" name="award" value="{{award.id}}" />
             </td>
             <td>
-                <img src="{{ MEDIA_URL }}dl/{{award.content}}" /><br/>
+                <img src="{{ MEDIA_URL }}{{award.content}}" /><br/>
               <strong>{{award.description}}</strong>
             </td>
           </tr>


### PR DESCRIPTION
The image links under "Give an award you've given before" are bad, because they contain `dl/` twice in succession.  This seems to be because `MEDIA_URL` already contains the `dl/` suffix, so therefore it gets inserted twice.

This change should theoretically fix that problem.