### PR TITLE
Fix error when no challenges exist

### DIFF
--- a/pyweek/challenge/views/context.py
+++ b/pyweek/challenge/views/context.py
@@ -4,7 +4,7 @@ from pyweek.challenge.models import Challenge, Entry
 def challenges(request):
     latest, previous = Challenge.objects.get_latest_and_previous()
 
-    challenge = latest if latest.isRegoOpen() else previous
+    challenge = latest if latest and latest.isRegoOpen() else previous
 
     unverified_emails = 0
     if not request.user.is_anonymous():


### PR DESCRIPTION
This fixes a fatal error when trying to view the PyWeek site with a freshly initialized database.