### PR TITLE
Fix showing "registration is open" after challenge is finished

### DIFF
--- a/pyweek/challenge/models.py
+++ b/pyweek/challenge/models.py
@@ -266,7 +266,7 @@ class Challenge(models.Model):
 
     def isRegoOpen(self):
         """Are we in the registration window for this challenge?"""
-        if self.is_rego_open:  # overridden by admin
+        if self.is_rego_open and not self.isCompFinished():  # overridden by admin
             return True
         now = datetime.datetime.utcnow()
         sd = self.start_utc()

--- a/pyweek/challenge/templates/base.html
+++ b/pyweek/challenge/templates/base.html
@@ -110,7 +110,7 @@ jQuery(function ($) {
             You have {{ unverified_emails }} unverified e-mail address{{ unverified_emails|pluralize:"es" }}.
             Visit <a href="/profile/">your account settings</a> to update and re-send verification.
 	</div>
-	{% elif latest and latest.summary and latest.isRegoOpen %}
+	{% elif latest and latest.summary and not latest.isCompComing %}
 	<div id="flash" style="text-align: center; border-top: solid #ec8 1px; border-bottom: solid #ec8 1px; background-color: #ffe6c0; padding: 0.3em;">
 		<a href="{{ latest.get_absolute_url }}">{{ latest.title }}</a>: {{ latest.summary|safe }}
 	</div>

--- a/pyweek/challenge/templates/base.html
+++ b/pyweek/challenge/templates/base.html
@@ -84,11 +84,9 @@ jQuery(function ($) {
             <li class="endsection"><a href="{% url 'draft-emails' %}">E-mail users</a></li>
             {% endif %}
 
-           {% if challenge and challenge.isRegoOpen %}
-            {% if not challenge.isCompFinished %}
-             <li class="endsection"><a href="/{{ challenge.number }}/entry_add/">Register Entry</a></li>
+            {% if challenge and challenge.isRegoOpen %}
+            <li class="endsection"><a href="/{{ challenge.number }}/entry_add/">Register Entry</a></li>
             {% endif %}
-           {% endif %}
 
            {% if user_entries %}
            <li class="sectiontitle">Your Latest Entries:</li>


### PR DESCRIPTION
Prevents a problem where, if the "Is rego open" box is ticked for a challenge, it would continue to show the "Next challenge" and "registration is now open" in the MOTD after the challenge had already ended.

There are some tweaks to the templates because the code showing the yellow banner relied on `isRegoOpen` continuing to return `True` in the judging period.

Fixes #34