### PR TITLE
Give proper message to yellow banner indicating upload period

### DIFF
--- a/pyweek/challenge/models.py
+++ b/pyweek/challenge/models.py
@@ -219,6 +219,9 @@ class Challenge(models.Model):
             diff = ed - now
             event = ['"%s" challenge underway;'%self.getTheme(),
                 '', 'to go']
+        elif now < ed + datetime.timedelta(1):
+            diff = ed - now + datetime.timedelta(1)
+            event = ['"%s" challenge is finished;'%self.getTheme(), '', 'to upload your entry']
         elif now < ed + datetime.timedelta(14):
             diff = ed - now + datetime.timedelta(14)
             event = ['Judging ends in', '', '']


### PR DESCRIPTION
Showing "Judging ends in…" in the yellow banner during the upload period is confusing because judging is not yet open.  This corrects the text in the banner to say this instead:

![image](https://user-images.githubusercontent.com/194842/63877323-b0005f00-c9c7-11e9-8bc5-1e32c15dbaa6.png)

Fixes #32