### PR TITLE
Fix typo enabling new entries before registration is open

### DIFF
--- a/pyweek/challenge/views/entry.py
+++ b/pyweek/challenge/views/entry.py
@@ -329,7 +329,7 @@ def rating_dashboard(request, challenge_id):
 def entry_add(request, challenge_id):
     challenge = get_object_or_404(models.Challenge, pk=challenge_id)
 
-    if not challenge.isRegoOpen:
+    if not challenge.isRegoOpen():
         return HttpResponseRedirect("/%s/" % challenge_id)
 
     if challenge.isCompFinished():


### PR DESCRIPTION
I happened to notice this typo, and decided to try seeing what happens when navigating to the `entry_add` page of a challenge that is not yet open, and sure enough, it lets me register new entries anyway.

This fixes that.