### PR TITLE
Don't allow joining a team for a challenge after registration closed

### DIFF
--- a/pyweek/challenge/templates/challenge/entries.html
+++ b/pyweek/challenge/templates/challenge/entries.html
@@ -62,7 +62,7 @@ The torrent file is <A href="{{ challenge.torrent_url }}">here</a>.</p>
   {% else %}
    Entrant: <a href="{% url 'user_display' e.user.username %}">{{ e.user.username }}</a>
   {% endif %}
-  {% if e.is_open %}&emsp;(<a href="{{ e.get_absolute_url }}" title="Open Team">Join this team?</a>){% endif %}
+  {% if e.is_open and e.challenge.isRegoOpen %}&emsp;(<a href="{{ e.get_absolute_url }}" title="Open Team">Join this team?</a>){% endif %}
   </p>
 {% endwith %}
 </div>

--- a/pyweek/challenge/templates/challenge/entry.html
+++ b/pyweek/challenge/templates/challenge/entry.html
@@ -41,7 +41,7 @@
 </p>
 {% endif %}
 
-{% if entry.is_open and not is_member %}
+{% if entry.is_open and not is_member and entry.challenge.isRegoOpen %}
 <h3>Open team</h3>
 <p>This team is accepting membership applications.</p>
 <form action="" method="POST">

--- a/pyweek/challenge/views/entry.py
+++ b/pyweek/challenge/views/entry.py
@@ -470,6 +470,12 @@ def entry_display(request, entry_id):
                         entry.title or entry.name
                     )
                 )
+            elif not entry.challenge.isRegoOpen():
+                messages.error(request,
+                    "You cannot join {} as the respective PyWeek challenge has ended.".format(
+                        entry.title or entry.name
+                    )
+                )
             elif is_member:
                 messages.error(
                     request,


### PR DESCRIPTION
This makes sure that the options to join a team are no longer shown after the registration for the respective challenge closes.

It's (presumably) still possible to *accept* already pending membership requests after the challenge is over.  That may also need to be fixed; maybe any pending requests should be cleared when the challenge closes?

Fixes #44