### PR TITLE
Fix "Membership Requests" and "Manage This Entry" links appearing inconsistently

### DIFF
--- a/pyweek/challenge/templates/entry_nav.html
+++ b/pyweek/challenge/templates/entry_nav.html
@@ -7,10 +7,10 @@
             <li><a href="/e/{{ entry.name }}/upload/">Upload File</a></li>
             <li><a href="/e/{{ entry.name }}/upload/">Add Screenshot</a></li>
             {% endif %}
-            {% if is_owner %}
-            {% if entry.is_open %}
+            {% if is_owner and entry.is_open %}
             <li><a href="/e/{{ entry.name }}/members/">Membership Requests</a></li>
             {% endif %}
+            {% if is_member %}
             <li><a href="/e/{{ entry.name }}/manage/">Manage This Entry</a></li>
             {% endif %}
         </ul>

--- a/pyweek/challenge/views/entry.py
+++ b/pyweek/challenge/views/entry.py
@@ -592,7 +592,7 @@ def entry_manage(request, entry_id):
             'entry': entry,
             'form': f,
             'is_member': True,
-            'is_owner': True,
+            'is_owner': entry.user == request.user,
         }
     )
 

--- a/pyweek/challenge/views/files.py
+++ b/pyweek/challenge/views/files.py
@@ -43,7 +43,7 @@ def entry_upload(request, entry_id):
         'entry': entry,
         'files': entry.file_set.all(),
         'is_member': True,
-        'is_owner': True,
+        'is_owner': entry.user == request.user,
         'form': f,
     }
 


### PR DESCRIPTION
By setting and using `is_owner`/`is_member` consistently, this fixes two things:

* The Membership Requests link erroneously appearing on the Upload page for non-owners, even though they get an error actually accessing the page
* The Manage This Entry link *not* appearing on the main page for non-owners, even though they *can* manage the entry

Evidence that managing an entry is indeed intended to be possible for non-owners can be found here:
https://github.com/pyweekorg/pyweekorg/blob/6e92c8ee249a0fb8aca7eb21ce20242770d1474e/pyweek/challenge/views/entry.py#L555-L559

Fixes #24