### PR TITLE
Prevent accessing the Ratings page before judging is over

### DIFF
--- a/pyweek/challenge/views/challenge.py
+++ b/pyweek/challenge/views/challenge.py
@@ -182,6 +182,10 @@ def challenge_diaries(request, challenge_id):
 def challenge_ratings(request, challenge_id):
     challenge = get_object_or_404(models.Challenge, pk=challenge_id)
     all_done = challenge.isAllDone()
+    if not all_done:
+        messages.error(request, 'Cannot view the ratings until the judging period is over!')
+        return HttpResponseRedirect("/%s/" % challenge_id)
+
     individual = []
     team = []
     for rating in models.RatingTally.objects.filter(challenge=challenge).order_by('-overall'):


### PR DESCRIPTION
It's apparently possible to view the ratings page for a challenge by just going to the ratings URL.  There appears to be no check of whether the judging period is over.

I realise that the tallies may not actually exist until the end of the period, but for the avoidance of doubt and as an extra check I would still recommend this change.