### PR TITLE
Hide link to give reward to own entry

### DIFF
--- a/pyweek/challenge/templates/challenge/entry.html
+++ b/pyweek/challenge/templates/challenge/entry.html
@@ -68,10 +68,11 @@
   </div>
 {% endfor %}
 
+{% if not is_member %}
 <p style="clear:left">
   <a href="/e/{{entry.name}}/give_award/">Give this entry an award</a>
 </p>
-
+{% endif %}
 
 {% if rating %}
 <h3>Scores</h3>


### PR DESCRIPTION
Giving an award to your own entry [is not possible](https://github.com/pyweekorg/pyweekorg/blob/ab98595c632d86a50b92d4fc26c5ab40c989d58c/pyweek/challenge/views/award.py#L54-L56), so why show it as a possible action?