### PR TITLE
Fix Discord channel name

### DIFF
--- a/pyweek/challenge/templates/challenge/index.html
+++ b/pyweek/challenge/templates/challenge/index.html
@@ -179,7 +179,7 @@ href="https://pyweek.readthedocs.io/en/latest/rules.html">challenge rules</a> fo
                 style="color: white; text-decoration: underline"
                 >
                 Join us on Discord</a>
-            and head to the <tt>#pyweek</tt> channel to chat with other
+            and head to the <tt>#pyweek-game-jam</tt> channel to chat with other
             PyWeekers!</p>
         </div>
     </div>

--- a/pyweek/challenge/templates/messages.html
+++ b/pyweek/challenge/templates/messages.html
@@ -27,7 +27,7 @@
         style="color: white; text-decoration: underline"
         >
         Join us on Discord</a>
-    and head to the <tt>#pyweek</tt> channel to chat with other
+    and head to the <tt>#pyweek-game-jam</tt> channel to chat with other
     PyWeekers!</p>
 
     <p><a


### PR DESCRIPTION
Uses the correct Discord channel name, `#pyweek-game-jam`, instead of `#pyweek`.