### PR TITLE
Migrate URL patterns to django.urls and add typing to root urlpatterns

### DIFF
--- a/pyweek/activity/urls.py
+++ b/pyweek/activity/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import timeline
 
 
 urlpatterns = [
-    url('^$', timeline, name='timeline'),
+    re_path(r"^$", timeline, name="timeline"),
 ]

--- a/pyweek/challenge/urls.py
+++ b/pyweek/challenge/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import re_path
 from pyweek.challenge.views.message import DiaryFeed
 from .views import (
     challenge, message, user, entry, files, poll, registration, award, pages,
@@ -6,69 +6,69 @@ from .views import (
 )
 
 urlpatterns = [
-    url(r'^$', challenge.index),
-    url(r'^stats/$', challenge.stats),
-    url(r'^stats.json$', challenge.stats_json),
+    re_path(r"^$", challenge.index),
+    re_path(r"^stats/$", challenge.stats),
+    re_path(r"^stats.json$", challenge.stats_json),
     #url(r'^test/$', 'test'),
     #url(r'^update_has_final/$', 'update_has_final'),
-    url(r'^all_games/$', challenge.all_games),
-    url(r'^challenges/$', challenge.previous_challenges),
+    re_path(r"^all_games/$", challenge.all_games),
+    re_path(r"^challenges/$", challenge.previous_challenges),
 
-    url(r'^(\d+)/$', challenge.challenge_display, name="challenge"),
-    url(r'^(\d+)/diaries/$', challenge.challenge_diaries),
-    url(r'^(\d+)/ratings/$', challenge.challenge_ratings),
+    re_path(r"^(\d+)/$", challenge.challenge_display, name="challenge"),
+    re_path(r"^(\d+)/diaries/$", challenge.challenge_diaries),
+    re_path(r"^(\d+)/ratings/$", challenge.challenge_ratings),
 
-    url(r'^(\d+)/downloads\.json$', api.challenge_downloads),
+    re_path(r"^(\d+)/downloads\.json$", api.challenge_downloads),
 
     # Message views
-    url(r'^messages/$', message.list_messages),
-    url(r'^message_add/$', message.message_add),
-    url(r'^d/(\d+)/$', message.diary_display, name="display-diary"),
-    url(r'^d/(\d+)/edit/$', message.diary_edit),
-    url(r'^d/(\d+)/delete/$', message.diary_delete),
-    url(r'^e/([\w-]+)/diary/$', message.entry_diary),
-    url(r'^d/feed/$', DiaryFeed(), name='diary_feed'),
-    url(r'^update_messages/$', message.update_messages),
+    re_path(r"^messages/$", message.list_messages),
+    re_path(r"^message_add/$", message.message_add),
+    re_path(r"^d/(\d+)/$", message.diary_display, name="display-diary"),
+    re_path(r"^d/(\d+)/edit/$", message.diary_edit),
+    re_path(r"^d/(\d+)/delete/$", message.diary_delete),
+    re_path(r"^e/([\w-]+)/diary/$", message.entry_diary),
+    re_path(r"^d/feed/$", DiaryFeed(), name="diary_feed"),
+    re_path(r"^update_messages/$", message.update_messages),
 
     # User views
-    url(r'^u/([\w\. \-\[\]!]+)/$', user.user_display, name='user_display'),
-    url(r'^u/([\w\. \-\[\]!]+)/delete_spam$', user.delete_spammer, name='delete_spammer'),
-    url(r'^profile_description/$', user.profile_description),
+    re_path(r"^u/([\w\. \-\[\]!]+)/$", user.user_display, name="user_display"),
+    re_path(r"^u/([\w\. \-\[\]!]+)/delete_spam$", user.delete_spammer, name="delete_spammer"),
+    re_path(r"^profile_description/$", user.profile_description),
 
     # Entry views
-    url(r'^(\d+)/entry_add/$', entry.entry_add),
-    url(r'^(\d+)/entries/$', entry.entry_list),
-    url(r'^(\d+)/rating-dashboard$', entry.rating_dashboard),
-    url(r'^e/([\w-]+)/$', entry.entry_display),
-    url(r'^e/([\w-]+)/manage/$', entry.entry_manage),
-    url(r'^e/([\w-]+)/members/$', entry.entry_requests),
-    url(r'^e/([\w-]+)/ratings/$', entry.entry_ratings),
+    re_path(r"^(\d+)/entry_add/$", entry.entry_add),
+    re_path(r"^(\d+)/entries/$", entry.entry_list),
+    re_path(r"^(\d+)/rating-dashboard$", entry.rating_dashboard),
+    re_path(r"^e/([\w-]+)/$", entry.entry_display),
+    re_path(r"^e/([\w-]+)/manage/$", entry.entry_manage),
+    re_path(r"^e/([\w-]+)/members/$", entry.entry_requests),
+    re_path(r"^e/([\w-]+)/ratings/$", entry.entry_ratings),
 
     # Files views
-    url(r'^e/([\w-]+)/upload/$', files.entry_upload),
-    url(r'^e/([\w-]+)/oup/$', files.oneshot_upload),
-    url(r'^e/([\w-]+)/delete/(.+)$', files.file_delete),
+    re_path(r"^e/([\w-]+)/upload/$", files.entry_upload),
+    re_path(r"^e/([\w-]+)/oup/$", files.oneshot_upload),
+    re_path(r"^e/([\w-]+)/delete/(.+)$", files.file_delete),
 
     # Poll views
-    url(r'^p/(\d+)/$', poll.poll_display),
-    url(r'^p/(\d+)/view/$', poll.poll_view),
-    url(r'^p/(\d+)/test/$', poll.poll_view),
+    re_path(r"^p/(\d+)/$", poll.poll_display),
+    re_path(r"^p/(\d+)/view/$", poll.poll_view),
+    re_path(r"^p/(\d+)/test/$", poll.poll_view),
 
     # Registration views
-    url(r'^login/', registration.login_page ),
-    url(r'^recover$', registration.recovery),
-    url(r'^logout/', registration.logout ),
-    url(r'^profile/$', registration.profile ),
-    url(r'^profile/verify$', registration.verify_email),
-    url(r'^register/', registration.register ),
-    url(r'^resetpw/', registration.resetpw ),
+    re_path(r"^login/", registration.login_page),
+    re_path(r"^recover$", registration.recovery),
+    re_path(r"^logout/", registration.logout),
+    re_path(r"^profile/$", registration.profile),
+    re_path(r"^profile/verify$", registration.verify_email),
+    re_path(r"^register/", registration.register),
+    re_path(r"^resetpw/", registration.resetpw),
 
     # Award views
-    url(r'^e/([\w-]+)/upload_award/$', award.upload_award),
-    url(r'^e/([\w-]+)/give_award/$', award.give_award),
-    url(r'^a/(\d+)/$', award.view_award),
-    url(r'^all_awards/$', award.view_all_awards),
+    re_path(r"^e/([\w-]+)/upload_award/$", award.upload_award),
+    re_path(r"^e/([\w-]+)/give_award/$", award.give_award),
+    re_path(r"^a/(\d+)/$", award.view_award),
+    re_path(r"^all_awards/$", award.view_all_awards),
 
     # Pages views
-    url(r'^s/(\w+)/$', pages.page),
+    re_path(r"^s/(\w+)/$", pages.page),
 ]

--- a/pyweek/mail/urls.py
+++ b/pyweek/mail/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url
+from django.urls import re_path
 
 from .views import (
     ComposeEmail, EditEmail, DraftEmailList, PreviewEmail, PreviewEmailText,
@@ -7,11 +7,11 @@ from .views import (
 
 
 urlpatterns = [
-    url('^$', DraftEmailList.as_view(), name='draft-emails'),
-    url('^unsubscribe$', unsubscribe, name='unsubscribe'),
-    url('^compose$', ComposeEmail.as_view(), name='compose-email'),
-    url(r'^(?P<pk>\d+)/$', PreviewEmail.as_view(), name='preview-email'),
-    url(r'^(?P<pk>\d+)/text$', PreviewEmailText.as_view(), name='preview-email-text'),
-    url(r'^(?P<pk>\d+)/edit$', EditEmail.as_view(), name='edit-email'),
-    url(r'^(?P<pk>\d+)/send$', send, name='send-email'),
+    re_path(r"^$", DraftEmailList.as_view(), name="draft-emails"),
+    re_path(r"^unsubscribe$", unsubscribe, name="unsubscribe"),
+    re_path(r"^compose$", ComposeEmail.as_view(), name="compose-email"),
+    re_path(r"^(?P<pk>\d+)/$", PreviewEmail.as_view(), name="preview-email"),
+    re_path(r"^(?P<pk>\d+)/text$", PreviewEmailText.as_view(), name="preview-email-text"),
+    re_path(r"^(?P<pk>\d+)/edit$", EditEmail.as_view(), name="edit-email"),
+    re_path(r"^(?P<pk>\d+)/send$", send, name="send-email"),
 ]

--- a/pyweek/urls.py
+++ b/pyweek/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import url, include
+from django.urls import URLPattern, URLResolver, include, path, re_path
 from django.contrib import admin
 from django.conf import settings
 from django.conf.urls.static import static
@@ -8,11 +8,13 @@ from django.views.generic.base import RedirectView
 
 admin.autodiscover()
 
-urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^emails/', include('pyweek.mail.urls')),
-    url(r'^latest/', include('pyweek.activity.urls')),
-    url(r'^media/dl/(?P<path>.*)',
-        RedirectView.as_view(url=settings.MEDIA_URL + '%(path)s')),
-    url(r'', include('pyweek.challenge.urls')),
+urlpatterns: list[URLPattern | URLResolver] = [
+    path("admin/", admin.site.urls),
+    path("emails/", include("pyweek.mail.urls")),
+    path("latest/", include("pyweek.activity.urls")),
+    re_path(
+        r"^media/dl/(?P<path>.*)",
+        RedirectView.as_view(url=settings.MEDIA_URL + "%(path)s"),
+    ),
+    path("", include("pyweek.challenge.urls")),
 ]


### PR DESCRIPTION
### Motivation

- Replace deprecated `django.conf.urls.url` usage with current `django.urls` APIs to ensure compatibility with Django 2+ and newer.
- Use `path`/`re_path` where appropriate for clearer routing and to support modern imports.
- Add a typed annotation for the root `urlpatterns` for improved static typing checks.

### Description

- Replaced imports from `django.conf.urls` with `django.urls` and switched all `url(...)` calls to `re_path(...)` in `pyweek/activity/urls.py`, `pyweek/challenge/urls.py`, and `pyweek/mail/urls.py`.
- Converted top-level routes in `pyweek/urls.py` to use `path(...)` for simple paths and `re_path(...)` for the regex-based media redirect, and updated imports accordingly.
- Added a type annotation `urlpatterns: list[URLPattern | URLResolver]` to the root `pyweek/urls.py` for better type checking.

### Testing

- Ran the Django test suite with `./manage.py test` and all tests passed.
- Ran static type checks with `mypy` and there were no type errors reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf666f59008328bf58ac8f9f618d58)